### PR TITLE
Fix get_chunk_number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -807,7 +807,14 @@ impl<S: Storage + Send + Sync + 'static> SelfEncryptor<S> {
         if self.get_num_chunks() == 0 {
             return 0;
         }
-        (position / self.get_chunk_size(0) as u64) as u32
+
+        let remainder = self.file_size % self.get_chunk_size(0) as u64;
+        if remainder == 0 || remainder >= MIN_CHUNK_SIZE as u64 ||
+            position < self.file_size - remainder - MIN_CHUNK_SIZE as u64
+        {
+            return (position / self.get_chunk_size(0) as u64) as u32;
+        }
+        self.get_num_chunks() - 1
     }
 }
 


### PR DESCRIPTION
This fixes the case where the penultimate chunk is `MAX_CHUNK_SIZE - MIN_CHUNK_SIZE`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/self_encryption/154)
<!-- Reviewable:end -->
