### PR TITLE
Make Storage::get take name as a slice instead of Vec

### DIFF
--- a/examples/basic_encryptor.rs
+++ b/examples/basic_encryptor.rs
@@ -96,7 +96,7 @@ struct DiskBasedStorage {
 }
 
 impl DiskBasedStorage {
-    fn calculate_path(&self, name: Vec<u8>) -> PathBuf {
+    fn calculate_path(&self, name: &[u8]) -> PathBuf {
         let mut path = PathBuf::from(self.storage_path.clone());
         path.push(file_name(&name));
         path
@@ -104,7 +104,7 @@ impl DiskBasedStorage {
 }
 
 impl Storage for DiskBasedStorage {
-    fn get(&self, name: Vec<u8>) -> Vec<u8> {
+    fn get(&self, name: &[u8]) -> Vec<u8> {
         let path = self.calculate_path(name);
         let display = path.display();
         let mut file = match File::open(&path) {
@@ -117,7 +117,7 @@ impl Storage for DiskBasedStorage {
     }
 
     fn put(&self, name: Vec<u8>, data: Vec<u8>) {
-        let path = self.calculate_path(name);
+        let path = self.calculate_path(&name);
         let mut file = match File::create(&path) {
             Err(error) => panic!("Failed to create {:?} - {:?}", path, error),
             Ok(f) => f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! }
 //!
 //! impl self_encryption::Storage for SimpleStorage {
-//!     fn get(&self, name: Vec<u8>) -> Vec<u8> {
+//!     fn get(&self, name: &[u8]) -> Vec<u8> {
 //!         let lock = self.entries.lock().unwrap();
 //!         for entry in lock.iter() {
 //!             if entry.name == name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,6 @@ enum ChunkLocation {
     Remote,
 }
 
-// pub struct Chunk { pub name:  Vec<u8>, pub content: Vec<u8> }
-
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Chunk {
     number: u32,
@@ -358,7 +356,7 @@ impl Extend<u8> for Sequencer {
 /// of content. Storage can be in-memory HashMap or disk based
 pub trait Storage {
     /// Fetch the data bearing the name
-    fn get(&self, name: Vec<u8>) -> Vec<u8>;
+    fn get(&self, name: &[u8]) -> Vec<u8>;
     /// Insert the data bearing the name.
     fn put(&self, name: Vec<u8>, data: Vec<u8>);
 }
@@ -710,7 +708,7 @@ impl<S: Storage + Send + Sync + 'static> SelfEncryptor<S> {
 
     /// Performs the decryption algorithm to decrypt chunk of data.
     fn decrypt_chunk(&self, chunk_number: u32) -> Deferred<Vec<u8>, String> {
-        let name = self.datamap.get_sorted_chunks()[chunk_number as usize].hash.clone();
+        let name = &self.datamap.get_sorted_chunks()[chunk_number as usize].hash;
         // [TODO]: work out passing functors properly - 2015-03-02 07:00pm
         let (pad, key, iv) = self.get_pad_key_and_iv(chunk_number);
         let content = self.storage.get(name);

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -60,7 +60,7 @@ impl SimpleStorage {
 }
 
 impl Storage for SimpleStorage {
-    fn get(&self, name: Vec<u8>) -> Vec<u8> {
+    fn get(&self, name: &[u8]) -> Vec<u8> {
         let lock = unwrap_result!(self.entries.lock());
         for entry in lock.iter() {
             if entry.name == name {


### PR DESCRIPTION
Caller can avoid needless clones.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/self_encryption/162)
<!-- Reviewable:end -->
