### PR TITLE
refactor/self-encryptor: remove asynchronous code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,16 @@ repository = "https://github.com/maidsafe/self_encryption"
 version = "0.3.1"
 
 [dependencies]
-asynchronous = "~0.4.5"
-clippy = {version = "~0.0.62", optional = true}
+clippy = {version = "~0.0.64", optional = true}
 flate2 = "~0.2.13"
-maidsafe_utilities = "~0.5.1"
+maidsafe_utilities = "~0.5.4"
 memmap = "~0.3.0"
 rand = "~0.3.14"
 rustc-serialize = "~0.3.19"
 sodiumoxide = "~0.0.10"
 
 [dev-dependencies]
-docopt = "~0.6.78"
+docopt = "~0.6.80"
 
 [[example]]
 name = "basic_encryptor"
-path = "examples/basic_encryptor.rs"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -41,21 +41,20 @@ extern crate test;
 use test::Bencher;
 use self_encryption::{DataMap, SelfEncryptor};
 use self_encryption::test_helpers::{random_bytes, SimpleStorage};
-use std::sync::Arc;
 
 #[bench]
 fn write_then_read_200_bytes(b: &mut Bencher) {
-    let my_storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let bytes_len = 200;
     b.iter(|| {
         let data_map: DataMap;
         let the_bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(my_storage.clone(), DataMap::None);
+            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
             se.write(&the_bytes, 0);
             data_map = se.close();
         }
-        let mut new_se = SelfEncryptor::new(my_storage.clone(), data_map);
+        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
         let fetched = new_se.read(0, bytes_len);
         assert_eq!(fetched, the_bytes);
     });
@@ -64,17 +63,17 @@ fn write_then_read_200_bytes(b: &mut Bencher) {
 
 #[bench]
 fn write_then_read_1_kilobyte(b: &mut Bencher) {
-    let my_storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let bytes_len = 1024;
     b.iter(|| {
         let data_map: DataMap;
         let the_bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(my_storage.clone(), DataMap::None);
+            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
             se.write(&the_bytes, 0);
             data_map = se.close();
         }
-        let mut new_se = SelfEncryptor::new(my_storage.clone(), data_map);
+        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
         let fetched = new_se.read(0, bytes_len);
         assert_eq!(fetched, the_bytes);
     });
@@ -83,17 +82,17 @@ fn write_then_read_1_kilobyte(b: &mut Bencher) {
 
 #[bench]
 fn write_then_read_1_megabyte(b: &mut Bencher) {
-    let my_storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let bytes_len = 1024 * 1024;
     b.iter(|| {
         let data_map: DataMap;
         let the_bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(my_storage.clone(), DataMap::None);
+            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
             se.write(&the_bytes, 0);
             data_map = se.close();
         }
-        let mut new_se = SelfEncryptor::new(my_storage.clone(), data_map);
+        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
         let fetched = new_se.read(0, bytes_len);
         assert_eq!(fetched, the_bytes);
     });
@@ -102,17 +101,17 @@ fn write_then_read_1_megabyte(b: &mut Bencher) {
 
 #[bench]
 fn write_then_read_3_megabytes(b: &mut Bencher) {
-    let my_storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let bytes_len = 3 * 1024 * 1024;
     b.iter(|| {
         let data_map: DataMap;
         let the_bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(my_storage.clone(), DataMap::None);
+            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
             se.write(&the_bytes, 0);
             data_map = se.close();
         }
-        let mut new_se = SelfEncryptor::new(my_storage.clone(), data_map);
+        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
         let fetched = new_se.read(0, bytes_len);
         assert_eq!(fetched, the_bytes);
     });
@@ -121,17 +120,17 @@ fn write_then_read_3_megabytes(b: &mut Bencher) {
 
 #[bench]
 fn write_then_read_10_megabytes(b: &mut Bencher) {
-    let my_storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let bytes_len = 10 * 1024 * 1024;
     b.iter(|| {
         let data_map: DataMap;
         let the_bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(my_storage.clone(), DataMap::None);
+            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
             se.write(&the_bytes, 0);
             data_map = se.close();
         }
-        let mut new_se = SelfEncryptor::new(my_storage.clone(), data_map);
+        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
         let fetched = new_se.read(0, bytes_len);
         assert_eq!(fetched, the_bytes);
     });
@@ -140,17 +139,17 @@ fn write_then_read_10_megabytes(b: &mut Bencher) {
 
 #[bench]
 fn write_then_read_100_megabytes(b: &mut Bencher) {
-    let storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let bytes_len = 100 * 1024 * 1024;
     b.iter(|| {
         let data_map: DataMap;
         let bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(storage.clone(), DataMap::None);
+            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
             se.write(&bytes, 0);
             data_map = se.close();
         }
-        let mut se = SelfEncryptor::new(storage.clone(), data_map);
+        let mut se = SelfEncryptor::new(&mut storage, data_map);
         let fetched = se.read(0, bytes_len);
         assert_eq!(fetched, bytes);
     });
@@ -159,7 +158,7 @@ fn write_then_read_100_megabytes(b: &mut Bencher) {
 
 #[bench]
 fn write_then_read_range(b: &mut Bencher) {
-    let storage = Arc::new(SimpleStorage::new());
+    let mut storage = SimpleStorage::new();
     let string_range = vec![512 * 1024,
                             1 * 1024 * 1024,
                             2 * 1024 * 1024,
@@ -172,11 +171,11 @@ fn write_then_read_range(b: &mut Bencher) {
             let data_map: DataMap;
             let the_bytes = random_bytes(bytes_len as usize);
             {
-                let mut se = SelfEncryptor::new(storage.clone(), DataMap::None);
+                let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
                 se.write(&the_bytes, 0);
                 data_map = se.close();
             }
-            let mut new_se = SelfEncryptor::new(storage.clone(), data_map);
+            let mut new_se = SelfEncryptor::new(&mut storage, data_map);
             let fetched = new_se.read(0, bytes_len);
             assert_eq!(fetched, the_bytes);
         });


### PR DESCRIPTION
This removes the asynchronous library from the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/self_encryption/178) &emsp; Multiple assignees:&emsp;<img alt="@afck" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/7894725?s=40&v=3">&nbsp;<a href="/maidsafe/self_encryption/pulls/assigned/afck">afck</a>,&emsp;<img alt="@ustulation" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/8788153?s=40&v=3">&nbsp;<a href="/maidsafe/self_encryption/pulls/assigned/ustulation">ustulation</a>
<!-- Reviewable:end -->
