### PR TITLE
refactor/benchmarks: remove duplicate code and improve benchmark tests

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -29,12 +29,9 @@
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations)]
 
-// the test names contain MB, KB which should retain capitalisation
 #![feature(test)]
 
 #[macro_use]
-#[allow(unused_extern_crates)]  // Only using macros from maidsafe_utilites
-extern crate maidsafe_utilities;
 extern crate self_encryption;
 extern crate test;
 
@@ -42,144 +39,53 @@ use test::Bencher;
 use self_encryption::{DataMap, SelfEncryptor};
 use self_encryption::test_helpers::{random_bytes, SimpleStorage};
 
-#[bench]
-fn write_then_read_200_bytes(b: &mut Bencher) {
+fn write_then_read(bencher: &mut Bencher, bytes_len: u64) {
     let mut storage = SimpleStorage::new();
-    let bytes_len = 200;
-    b.iter(|| {
+    let bytes = random_bytes(bytes_len as usize);
+    bencher.iter(|| {
         let data_map: DataMap;
-        let the_bytes = random_bytes(bytes_len as usize);
         {
-            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-            se.write(&the_bytes, 0);
-            data_map = se.close();
+            let mut self_encryptor = SelfEncryptor::new(&mut storage, DataMap::None);
+            self_encryptor.write(&bytes, 0);
+            data_map = self_encryptor.close();
         }
-        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
-        let fetched = new_se.read(0, bytes_len);
-        assert_eq!(fetched, the_bytes);
+        let mut self_encryptor = SelfEncryptor::new(&mut storage, data_map);
+        assert!(self_encryptor.read(0, bytes_len) == bytes);
     });
-    b.bytes = 2 * bytes_len;
+    bencher.bytes = 2 * bytes_len;
 }
 
 #[bench]
-fn write_then_read_1_kilobyte(b: &mut Bencher) {
-    let mut storage = SimpleStorage::new();
-    let bytes_len = 1024;
-    b.iter(|| {
-        let data_map: DataMap;
-        let the_bytes = random_bytes(bytes_len as usize);
-        {
-            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-            se.write(&the_bytes, 0);
-            data_map = se.close();
-        }
-        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
-        let fetched = new_se.read(0, bytes_len);
-        assert_eq!(fetched, the_bytes);
-    });
-    b.bytes = 2 * bytes_len;
+fn write_then_read_200_bytes(bencher: &mut Bencher) {
+    write_then_read(bencher, 200)
 }
 
 #[bench]
-fn write_then_read_1_megabyte(b: &mut Bencher) {
-    let mut storage = SimpleStorage::new();
-    let bytes_len = 1024 * 1024;
-    b.iter(|| {
-        let data_map: DataMap;
-        let the_bytes = random_bytes(bytes_len as usize);
-        {
-            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-            se.write(&the_bytes, 0);
-            data_map = se.close();
-        }
-        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
-        let fetched = new_se.read(0, bytes_len);
-        assert_eq!(fetched, the_bytes);
-    });
-    b.bytes = 2 * bytes_len;
+fn write_then_read_1_kilobyte(bencher: &mut Bencher) {
+    write_then_read(bencher, 1024)
 }
 
 #[bench]
-fn write_then_read_3_megabytes(b: &mut Bencher) {
-    let mut storage = SimpleStorage::new();
-    let bytes_len = 3 * 1024 * 1024;
-    b.iter(|| {
-        let data_map: DataMap;
-        let the_bytes = random_bytes(bytes_len as usize);
-        {
-            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-            se.write(&the_bytes, 0);
-            data_map = se.close();
-        }
-        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
-        let fetched = new_se.read(0, bytes_len);
-        assert_eq!(fetched, the_bytes);
-    });
-    b.bytes = 2 * bytes_len;
+fn write_then_read_512_kilobytes(bencher: &mut Bencher) {
+    write_then_read(bencher, 512 * 1024)
 }
 
 #[bench]
-fn write_then_read_10_megabytes(b: &mut Bencher) {
-    let mut storage = SimpleStorage::new();
-    let bytes_len = 10 * 1024 * 1024;
-    b.iter(|| {
-        let data_map: DataMap;
-        let the_bytes = random_bytes(bytes_len as usize);
-        {
-            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-            se.write(&the_bytes, 0);
-            data_map = se.close();
-        }
-        let mut new_se = SelfEncryptor::new(&mut storage, data_map);
-        let fetched = new_se.read(0, bytes_len);
-        assert_eq!(fetched, the_bytes);
-    });
-    b.bytes = 2 * bytes_len;
+fn write_then_read_1_megabyte(bencher: &mut Bencher) {
+    write_then_read(bencher, 1024 * 1024)
 }
 
 #[bench]
-fn write_then_read_100_megabytes(b: &mut Bencher) {
-    let mut storage = SimpleStorage::new();
-    let bytes_len = 100 * 1024 * 1024;
-    b.iter(|| {
-        let data_map: DataMap;
-        let bytes = random_bytes(bytes_len as usize);
-        {
-            let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-            se.write(&bytes, 0);
-            data_map = se.close();
-        }
-        let mut se = SelfEncryptor::new(&mut storage, data_map);
-        let fetched = se.read(0, bytes_len);
-        assert_eq!(fetched, bytes);
-    });
-    b.bytes = 2 * bytes_len;
+fn write_then_read_3_megabytes(bencher: &mut Bencher) {
+    write_then_read(bencher, 3 * 1024 * 1024)
 }
 
 #[bench]
-fn write_then_read_range(b: &mut Bencher) {
-    let mut storage = SimpleStorage::new();
-    let string_range = vec![512 * 1024,
-                            1 * 1024 * 1024,
-                            2 * 1024 * 1024,
-                            3 * 1024 * 1024,
-                            4 * 1024 * 1024,
-                            5 * 1024 * 1024,
-                            6 * 1024 * 1024];
-    for bytes_len in string_range {
-        b.iter(|| {
-            let data_map: DataMap;
-            let the_bytes = random_bytes(bytes_len as usize);
-            {
-                let mut se = SelfEncryptor::new(&mut storage, DataMap::None);
-                se.write(&the_bytes, 0);
-                data_map = se.close();
-            }
-            let mut new_se = SelfEncryptor::new(&mut storage, data_map);
-            let fetched = new_se.read(0, bytes_len);
-            assert_eq!(fetched, the_bytes);
-        });
-        // write and read the data
-        b.bytes = 2 * bytes_len;
-    }
+fn write_then_read_10_megabytes(bencher: &mut Bencher) {
+    write_then_read(bencher, 10 * 1024 * 1024)
+}
+
+#[bench]
+fn write_then_read_100_megabytes(bencher: &mut Bencher) {
+    write_then_read(bencher, 100 * 1024 * 1024)
 }


### PR DESCRIPTION
This moves the generation of random data for benchmark tests outside of the actual code block being
measured.  It also removes code which was duplicated across all benchmark tests, and removes a
needless benchmark test entirely.