### PR TITLE
fix/appveyor: replace Start-FileDownload cmdlet with curl

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ clone_depth: 50
 install:
   - ps: |
         $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
-        Start-FileDownload "$url/Install%20Rustup.ps1" -FileName "Install Rustup.ps1"
-        Start-FileDownload "$url/Build.ps1" -FileName "Build.ps1"
-        Start-FileDownload "$url/Run%20Tests.ps1" -FileName "Run Tests.ps1"
+        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
+        cmd /c curl -fsSL -o "Build.ps1" "$url/Build.ps1"
+        cmd /c curl -fsSL -o "Run Tests.ps1" "$url/Run%20Tests.ps1"
         . ".\Install Rustup.ps1"
 
 platform:


### PR DESCRIPTION
`curl` options used:

- `f` - Fail silently without downloading failure meta file
- `s` - silence output
- `S` - show error on failure
- `L` - follow through with redirect