### PR TITLE
chore/ci: update scripts to Rust stable 1.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-    - RUST_STABLE=1.26.2
-    - RUST_NIGHTLY=nightly-2018-06-10
-    - RUST_RUSTFMT=0.8.2
-    - RUST_CLIPPY=0.0.207
+    - RUST_STABLE=1.28.0
+    - RUST_NIGHTLY=nightly-2018-07-07
+    - RUST_RUSTFMT=0.99.2
+    - RUST_CLIPPY=0.0.212
 os:
   - linux
   - osx
 language: rust
 rust:
-  - 1.26.2
-  - nightly-2018-06-10
+  - 1.28.0
+  - nightly-2018-07-07
 sudo: false
 cache:
   cargo: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.26.2
+    - RUST_TOOLCHAIN: 1.28.0
 
 cache:
   - '%USERPROFILE%\.cargo'

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -9,20 +9,48 @@
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(
-    bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items, unknown_crate_types,
+    bad_style,
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
     warnings
 )]
 #![deny(
-    deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns, overflowing_literals,
-    plugin_as_library, private_no_mangle_fns, private_no_mangle_statics, stable_features,
-    unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
-    unused_attributes, unused_comparisons, unused_features, unused_parens, while_true
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    private_no_mangle_fns,
+    private_no_mangle_statics,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true
 )]
 #![warn(
-    trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_qualifications, unused_results, variant_size_differences
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results,
+    variant_size_differences
 )]
-#![allow(box_pointers, missing_copy_implementations, missing_debug_implementations)]
+#![allow(
+    box_pointers,
+    missing_copy_implementations,
+    missing_debug_implementations
+)]
 #![feature(test)]
 
 extern crate futures;

--- a/examples/basic_encryptor.rs
+++ b/examples/basic_encryptor.rs
@@ -11,20 +11,46 @@
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(
-    exceeding_bitshifts, mutable_transmutes, no_mangle_const_items, unknown_crate_types, warnings
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
+    warnings
 )]
 #![deny(
-    bad_style, deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
-    overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
-    stable_features, unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
-    unused_attributes, unused_comparisons, unused_features, unused_parens, while_true
+    bad_style,
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    private_no_mangle_fns,
+    private_no_mangle_statics,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true
 )]
 #![warn(
-    trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_qualifications, unused_results
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
 )]
 #![allow(
-    box_pointers, missing_copy_implementations, missing_debug_implementations,
+    box_pointers,
+    missing_copy_implementations,
+    missing_debug_implementations,
     variant_size_differences
 )]
 
@@ -153,8 +179,7 @@ impl Storage for DiskBasedStorage {
             .write_all(&data[..])
             .map(|_| {
                 println!("Chunk written to {:?}", path);
-            })
-            .map_err(From::from);
+            }).map_err(From::from);
         Box::new(future::result(result))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,25 +132,55 @@
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(
-    exceeding_bitshifts, mutable_transmutes, no_mangle_const_items, unknown_crate_types, warnings
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
+    warnings
 )]
 #![deny(
-    bad_style, deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
-    overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
-    stable_features, unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
-    unused_attributes, unused_comparisons, unused_features, unused_parens, while_true
+    bad_style,
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    private_no_mangle_fns,
+    private_no_mangle_statics,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true
 )]
 #![warn(
-    trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_qualifications, unused_results
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
 )]
 #![allow(
-    box_pointers, missing_copy_implementations, missing_debug_implementations,
-    variant_size_differences, non_camel_case_types
+    box_pointers,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    variant_size_differences,
+    non_camel_case_types
 )]
 // Doesn't allow casts on constants yet, remove when issue is fixed:
 // https://github.com/rust-lang-nursery/rust-clippy/issues/2267
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless, decimal_literal_representation))]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(cast_lossless, decimal_literal_representation)
+)]
 
 extern crate brotli;
 extern crate futures;

--- a/src/self_encryptor.rs
+++ b/src/self_encryptor.rs
@@ -138,8 +138,7 @@ where
                 for (p, byte) in state.sequencer.iter_mut().skip(position as usize).zip(data) {
                     *p = byte;
                 }
-            })
-            .into_box()
+            }).into_box()
     }
 
     /// The returned content is read from the specified `position` with specified `length`.  Trying
@@ -162,8 +161,7 @@ where
                     .take(length as usize)
                     .cloned()
                     .collect()
-            })
-            .into_box()
+            }).into_box()
     }
 
     /// This function returns a `DataMap`, which is the info required to recover encrypted content
@@ -224,12 +222,10 @@ where
                     };
 
                     prepare_window_for_reading(state0, byte_start, byte_end - byte_start)
-                })
-                .and_then(move |_| {
+                }).and_then(move |_| {
                     let mut state = state1.borrow_mut();
                     state.create_data_map(resized_start as usize)
-                })
-                .into_box()
+                }).into_box()
         };
 
         future_data_map
@@ -288,8 +284,7 @@ where
                         };
 
                         prepare_window_for_reading(state, 0, byte_end)
-                    })
-                    .into_box()
+                    }).into_box()
             } else {
                 future::ok(()).into_box()
             };
@@ -302,8 +297,7 @@ where
                         chunk.status = ChunkStatus::ToBeHashed;
                         chunk.in_sequencer = true;
                     }
-                })
-                .into_box()
+                }).into_box()
         } else {
             future::ok(()).into_box()
         };
@@ -314,8 +308,7 @@ where
                 let mut state = state.borrow_mut();
                 state.sequencer.truncate(new_size as usize);
                 state.file_size = new_size;
-            })
-            .into_box()
+            }).into_box()
     }
 
     /// Current file size as is known by encryptor.
@@ -506,8 +499,7 @@ where
             for &i in &next_two {
                 state.chunks[i].flag_for_encryption();
             }
-        })
-        .into_box()
+        }).into_box()
 }
 
 fn prepare_window_for_reading<S>(
@@ -562,8 +554,7 @@ where
                     *p = byte
                 }
             }
-        })
-        .into_box()
+        }).into_box()
 }
 
 fn decrypt_chunk<S>(
@@ -583,14 +574,12 @@ where
         .and_then(move |content| {
             let xor_result = xor(&content, &pad);
             encryption::decrypt(&xor_result, &key, &iv).map_err(|_| SelfEncryptionError::Decryption)
-        })
-        .and_then(|decrypted| {
+        }).and_then(|decrypted| {
             let mut decompressed = vec![];
             brotli::BrotliDecompress(&mut Cursor::new(decrypted), &mut decompressed)
                 .map(|_| decompressed)
                 .map_err(|_| SelfEncryptionError::Compression)
-        })
-        .into_box()
+        }).into_box()
 }
 
 fn encrypt_chunk<E: StorageError>(

--- a/src/sequential/encryptor.rs
+++ b/src/sequential/encryptor.rs
@@ -188,8 +188,7 @@ where
             .and_then(move |next_state| next_state.write(&data))
             .map(move |next_state| {
                 *curr_state.borrow_mut() = next_state;
-            })
-            .into_box()
+            }).into_box()
     }
 
     /// This finalises the encryptor - it should not be used again after this call.  Internal

--- a/src/sequential/large_encryptor.rs
+++ b/src/sequential/large_encryptor.rs
@@ -115,8 +115,7 @@ where
                         buffer,
                     }
                 },
-            )
-            .into_box()
+            ).into_box()
     }
 
     pub fn from_medium(

--- a/src/sequential/medium_encryptor.rs
+++ b/src/sequential/medium_encryptor.rs
@@ -64,8 +64,7 @@ where
                     buffer,
                     original_chunks: Some(chunks),
                 }
-            })
-            .into_box()
+            }).into_box()
     }
 
     // Simply appends to internal buffer assuming the size limit is not exceeded.  No chunks are

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,26 +9,54 @@
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(
-    bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items, unknown_crate_types,
+    bad_style,
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
     warnings
 )]
 #![deny(
-    deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns, overflowing_literals,
-    plugin_as_library, private_no_mangle_fns, private_no_mangle_statics, stable_features,
-    unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
-    unused_attributes, unused_comparisons, unused_features, unused_parens, while_true
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    private_no_mangle_fns,
+    private_no_mangle_statics,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true
 )]
 #![warn(
-    trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_qualifications, unused_results
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
 )]
 #![allow(
-    box_pointers, missing_copy_implementations, missing_debug_implementations,
+    box_pointers,
+    missing_copy_implementations,
+    missing_debug_implementations,
     variant_size_differences
 )]
 // Doesn't allow casts on constants yet, remove when issue is fixed:
 // https://github.com/rust-lang-nursery/rust-clippy/issues/2267
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless, decimal_literal_representation))]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(cast_lossless, decimal_literal_representation)
+)]
 
 extern crate futures;
 extern crate rand;
@@ -113,8 +141,7 @@ fn new_read() {
                         .expect(&format!(
                             "Reading attempt {} from encryptor shouldn't fail",
                             i
-                        ))
-                        .iter()
+                        )).iter()
                         .cloned(),
                 );
                 assert_eq!(original[0..(read_position + read_size)].to_vec(), decrypted);


### PR DESCRIPTION
nightly to 2018-07-07
clippy to 0.0.212
rustfmt to 0.99.2