### PR TITLE
refactor/sequencer: removes memory mapping logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Self-Encryption - Change Log
 
+[Unreleased]
+- Removes memmap dependency
+- Leaves mmap behavior to system allocator, now that jemalloc is no longer default
+
 ## [0.13.0]
 - Upgrade unwrap version to 1.2.0
 - Use rust 1.28.0 stable / 2018-07-07 nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 [dependencies]
 brotli = "~2.1.0"
 futures = "~0.1.15"
-memmap = "~0.5.2"
 rand = "~0.3.15"
 rust_sodium = "~0.10.0"
 serde = "~1.0.24"

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -6,121 +6,57 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::MAX_FILE_SIZE;
-use memmap::{Mmap, Protection};
-use std::io::Error as IoError;
-use std::io::Write;
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 
-pub const MAX_IN_MEMORY_SIZE: usize = 50 * 1024 * 1024;
-
-enum Data {
-    Vector(Vec<u8>),
-    Mmap(Mmap),
-}
-
-/// Optionally create a sequence of bytes via a vector or memory map.
 pub struct Sequencer {
-    data: Data,
+    data: Vec<u8>,
 }
 
 #[allow(clippy::len_without_is_empty)]
 impl Sequencer {
-    /// Initialise as a vector.
-    pub fn new_as_vector() -> Sequencer {
-        Sequencer {
-            data: Data::Vector(Vec::with_capacity(MAX_IN_MEMORY_SIZE)),
-        }
-    }
-
-    /// Initialise as a memory map
-    pub fn new_as_mmap() -> Result<Sequencer, IoError> {
-        Ok(Sequencer {
-            data: Data::Mmap(Mmap::anonymous(MAX_FILE_SIZE, Protection::ReadWrite)?),
-        })
+    pub fn new() -> Sequencer {
+        Sequencer { data: Vec::new() }
     }
 
     /// Return the current length of the sequencer.
     pub fn len(&self) -> usize {
-        match self.data {
-            Data::Vector(ref vector) => vector.len(),
-            Data::Mmap(ref mmap) => mmap.len(),
-        }
+        self.data.len()
     }
 
-    #[allow(unsafe_code)]
     /// Initialise with the Sequencer with 'content'.
     pub fn init(&mut self, content: &[u8]) {
-        match self.data {
-            Data::Vector(ref mut vector) => vector.extend_from_slice(content),
-            Data::Mmap(ref mut mmap) => {
-                let _ = unsafe { mmap.as_mut_slice() }.write_all(&content[..]);
-            }
-        }
+        self.data.extend_from_slice(content);
     }
 
-    /// Truncate internal object to given size. Note that this affects the vector only since the
-    /// memory map is a fixed size.
+    /// Truncate internal object to given size.
     pub fn truncate(&mut self, size: usize) {
-        if let Data::Vector(ref mut vector) = self.data {
-            vector.truncate(size);
-        }
-    }
-
-    #[allow(unsafe_code)]
-    /// Create a memory map if we haven't already done so.
-    pub fn create_mapping(&mut self) -> Result<(), IoError> {
-        self.data = match self.data {
-            Data::Mmap(_) => return Ok(()),
-            Data::Vector(ref mut vector) => {
-                let mut mmap = Mmap::anonymous(MAX_FILE_SIZE, Protection::ReadWrite)?;
-                let _ = unsafe { mmap.as_mut_slice() }.write_all(&vector[..]);
-                Data::Mmap(mmap)
-            }
-        };
-        Ok(())
+        self.data.truncate(size);
     }
 }
 
-#[allow(unsafe_code)]
 impl Index<usize> for Sequencer {
     type Output = u8;
     fn index(&self, index: usize) -> &u8 {
-        match self.data {
-            Data::Vector(ref vector) => &vector[index],
-            Data::Mmap(ref mmap) => unsafe { &mmap.as_slice()[index] },
-        }
+        &self.data[index]
     }
 }
 
-#[allow(unsafe_code)]
 impl IndexMut<usize> for Sequencer {
     fn index_mut(&mut self, index: usize) -> &mut u8 {
-        match self.data {
-            Data::Vector(ref mut vector) => &mut vector[index],
-            Data::Mmap(ref mut mmap) => unsafe { &mut mmap.as_mut_slice()[index] },
-        }
+        &mut self.data[index]
     }
 }
 
-#[allow(unsafe_code)]
 impl Deref for Sequencer {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
-        match self.data {
-            Data::Vector(ref vector) => &*vector,
-            Data::Mmap(ref mmap) => unsafe { mmap.as_slice() },
-        }
+        &*self.data
     }
 }
 
-#[allow(unsafe_code)]
 impl DerefMut for Sequencer {
     fn deref_mut(&mut self) -> &mut [u8] {
-        match self.data {
-            Data::Vector(ref mut vector) => &mut *vector,
-            Data::Mmap(ref mut mmap) => unsafe { &mut *mmap.as_mut_slice() },
-        }
+        &mut *self.data
     }
 }
 
@@ -129,8 +65,6 @@ impl Extend<u8> for Sequencer {
     where
         I: IntoIterator<Item = u8>,
     {
-        if let Data::Vector(ref mut vector) = self.data {
-            vector.extend(iterable);
-        }
+        self.data.extend(iterable);
     }
 }


### PR DESCRIPTION
  - Removes memmap crate, and logic, in order to compile for WASM target
    Rust 1.32.0 removes jemalloc as default, opting for system allocator
    such as malloc on Unix, HeapAlloc on Windows, and dlmalloc for WASM.
  - Removes unsafe code

Background reading: https://forum.safedev.org/t/writing-a-core-library-in-rust-possibilities-for-safe-browser-wasm/2288

Running tests sequentially, watching memory allocation with `top` and other tools, observing freed memory returned to OS.

However, manually testing, I'm not seeing observable differences between `jemalloc`, `malloc` and anonymous mapping, as far as allocation and freeing goes. What is consistent is the inevitable memory leak for all 3 when processing very large files, like greater than 2 GiB.
I'm observing over 3 times the file size allocated in-memory.
That might be for another task to find out why.

Closes #140 