### PR TITLE
chore/clippy: removed unused import as per cargo clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,8 +185,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate unwrap;
 
-use brotli;
-
 mod data_map;
 mod encryption;
 mod error;


### PR DESCRIPTION
Failing CI due to an unused import being flagged by `cargo clippy`