### PR TITLE
chore/deps: update tiny_keccak and fix clippy for latest rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand = "~0.3.15"
 rust_sodium = "~0.10.0"
 serde = "~1.0.24"
 serde_derive = "~1.0.24"
-tiny-keccak = "~1.3.0"
+tiny-keccak = "~1.4.0"
 unwrap = "~1.2.0"
 
 [dev-dependencies]

--- a/src/self_encryptor.rs
+++ b/src/self_encryptor.rs
@@ -824,7 +824,7 @@ mod tests {
 
     #[test]
     // Sorry
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     fn helper_functions() {
         let mut file_size = MIN_CHUNK_SIZE as u64 * 3;
         assert_eq!(get_num_chunks(file_size), 3);


### PR DESCRIPTION
Fixes dependency issue for  `safe_nd`.