### PR TITLE
chore: use deny(warnings) instead of forbid(warnings)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,10 +33,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@
 
 name: PR
 
-on: [pull_request, push]
+on: [pull_request]
 
 env:
   # Run all cargo commands with --verbose.
@@ -27,10 +27,6 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -61,10 +57,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -133,10 +125,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -13,8 +13,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     deprecated,
@@ -31,7 +30,8 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    warnings
 )]
 #![warn(
     trivial_casts,

--- a/examples/basic_encryptor.rs
+++ b/examples/basic_encryptor.rs
@@ -14,8 +14,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     bad_style,
@@ -34,7 +33,8 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    warnings
 )]
 #![warn(
     trivial_casts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     bad_style,
@@ -140,7 +139,8 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    warnings
 )]
 #![warn(
     trivial_casts,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -13,8 +13,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     deprecated,
@@ -32,7 +31,8 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    warnings
 )]
 #![warn(
     trivial_casts,


### PR DESCRIPTION
`deny` can be overriden with `allow`, unlike `forbid`. This allows us to `allow` some warnings on a case-by-case basis which is especially useful in macros. Without this, some macros from other crates caused compilation errors on nightly, however it's possible it would eventually affect stable as well.