### PR TITLE
Update tiny-keccak from 1.5.0 to 2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,15 @@ brotli = "3.3.0"
 futures = "~0.3.4"
 rand = "~0.7.3"
 rand_chacha = "~0.2.2"
-tiny-keccak = "1.5.0"
 err-derive = "0.2.4"
 
   [dependencies.serde]
   version = "1.0.97"
   features = [ "derive" ]
+
+  [dependencies.tiny-keccak]
+  version = "2.0.2"
+  features = [ "sha3" ]
 
   [dependencies.tokio]
   version = "~0.2.18"

--- a/examples/basic_encryptor.rs
+++ b/examples/basic_encryptor.rs
@@ -63,7 +63,7 @@ use std::{
     path::PathBuf,
     string::String,
 };
-use tiny_keccak::sha3_256;
+use tiny_keccak::{Hasher, Sha3};
 
 #[rustfmt::skip]
 static USAGE: &str = "
@@ -133,7 +133,11 @@ impl Storage for DiskBasedStorage {
     }
 
     async fn generate_address(&self, data: &[u8]) -> Result<Vec<u8>, SelfEncryptionError> {
-        Ok(sha3_256(data).to_vec())
+        let mut hasher = Sha3::v256();
+        let mut output = [0; 32];
+        hasher.update(&data);
+        hasher.finalize(&mut output);
+        Ok(output.to_vec())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! # extern crate futures;
 //! # extern crate self_encryption;
 //! use self_encryption::Storage;
-//! use tiny_keccak::sha3_256;
+//! use tiny_keccak::{Hasher, Sha3};
 //! use async_trait::async_trait;
 //! use self_encryption::SelfEncryptionError;
 
@@ -73,7 +73,11 @@
 //!    }
 //!
 //!    async fn generate_address(&self, data: &[u8]) -> Result<Vec<u8>, SelfEncryptionError> {
-//!         Ok(sha3_256(data).to_vec())
+//!         let mut hasher = Sha3::v256();
+//!         let mut output = [0; 32];
+//!         hasher.update(&data);
+//!         hasher.finalize(&mut output);
+//!         Ok(output.to_vec())
 //!    }
 //! }
 

--- a/src/sequential/utils.rs
+++ b/src/sequential/utils.rs
@@ -54,8 +54,10 @@ pub fn encrypt_chunk(
 ) -> Result<Vec<u8>, SelfEncryptionError> {
     let (pad, key, iv) = pad_key_iv;
     let mut compressed = vec![];
-    let mut enc_params: BrotliEncoderParams = Default::default();
-    enc_params.quality = COMPRESSION_QUALITY;
+    let enc_params = BrotliEncoderParams {
+        quality: COMPRESSION_QUALITY,
+        ..Default::default()
+    };
     let _size = brotli::BrotliCompress(&mut Cursor::new(content), &mut compressed, &enc_params)?;
     let encrypted = encryption::encrypt(&compressed, &key, &iv)?;
     Ok(xor(&encrypted, &pad))

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -20,7 +20,7 @@ use std::{
     fmt::{self, Debug, Formatter},
     thread,
 };
-use tiny_keccak::sha3_256;
+use tiny_keccak::{Hasher, Sha3};
 
 pub type TestRng = ChaChaRng;
 
@@ -82,7 +82,11 @@ impl Storage for SimpleStorage {
     }
 
     async fn generate_address(&self, data: &[u8]) -> Result<Vec<u8>, SelfEncryptionError> {
-        Ok(sha3_256(data).to_vec())
+        let mut hasher = Sha3::v256();
+        let mut output = [0; 32];
+        hasher.update(&data);
+        hasher.finalize(&mut output);
+        Ok(output.to_vec())
     }
 }
 


### PR DESCRIPTION
In sn_api the majority of dependencies use tiny-keccak 2.0.2 so it makes sense to have them all at the same version.

```
sn_api (master) $  cargo tree -i tiny-keccak:1.5.0
tiny-keccak v1.5.0
├── self_encryption v0.19.8
│   └── sn_client v0.46.2
│       └── sn_api v0.18.0 (/tmp/sn_api/sn_api)
│           ├── sn_authd v0.1.0 (/tmp/sn_api/sn_authd)
│           ├── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
│           └── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities)
│               [dev-dependencies]
│               └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
├── sn_client v0.46.2 (*)
├── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities) (*)
└── sn_data_types v0.14.3
    ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
    ├── sn_client v0.46.2 (*)
    ├── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities) (*)
    ├── sn_messaging v3.0.0
    │   └── sn_client v0.46.2 (*)
    └── sn_transfers v0.3.1
        └── sn_client v0.46.2 (*)
    [dev-dependencies]
    └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
[dev-dependencies]
└── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)

sn_api (master) $  cargo tree -i tiny-keccak:2.0.2
tiny-keccak v2.0.2
├── sn_messaging v3.0.0
│   └── sn_client v0.46.2
│       └── sn_api v0.18.0 (/tmp/sn_api/sn_api)
│           ├── sn_authd v0.1.0 (/tmp/sn_api/sn_authd)
│           ├── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
│           └── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities)
│               [dev-dependencies]
│               └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
├── threshold_crypto v0.4.0
│   ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
│   ├── sn_client v0.46.2 (*)
│   ├── sn_data_types v0.14.3
│   │   ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
│   │   ├── sn_client v0.46.2 (*)
│   │   ├── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities) (*)
│   │   ├── sn_messaging v3.0.0 (*)
│   │   └── sn_transfers v0.3.1
│   │       └── sn_client v0.46.2 (*)
│   │   [dev-dependencies]
│   │   └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
│   ├── sn_messaging v3.0.0 (*)
│   └── sn_transfers v0.3.1 (*)
└── xor_name v1.1.9
    ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
    ├── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
    ├── sn_client v0.46.2 (*)
    ├── sn_data_types v0.14.3 (*)
    ├── sn_messaging v3.0.0 (*)
    └── sn_transfers v0.3.1 (*)
    [dev-dependencies]
    └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
```