### PR TITLE
fix: mark Boxed Future as Send

### DIFF
--- a/src/self_encryptor.rs
+++ b/src/self_encryptor.rs
@@ -575,7 +575,7 @@ where
 async fn decrypt_chunk<S>(
     state: &mut State<S>,
     chunk_number: usize,
-) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, SelfEncryptionError>>>>
+) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, SelfEncryptionError>> + Send>>
 where
     S: Storage + 'static + Send + Sync + Clone,
 {


### PR DESCRIPTION
The decrypt_chunk function is a function used by many higher level
functions and crates. Without specifying the Send constraint, all
async functions relying on this function will be non-Send.

This shouldn't be dangerous, as the Boxed Future is actually Send-able
as witnessed by the fact the compiler does not complain.

Should fix:
https://github.com/maidsafe/safe_network/issues/62
https://github.com/maidsafe/sn_client/issues/1555