### PR TITLE
fix(seek): avoid range out of bounds panic

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -14,7 +14,6 @@ use xor_name::XorName;
 ///
 #[derive(Clone)]
 pub(crate) struct EncryptionBatch {
-    pub(crate) data_size: usize,
     pub(crate) raw_chunks: Vec<RawChunk>,
 }
 
@@ -58,7 +57,6 @@ pub(crate) fn batch_chunks(bytes: Bytes) -> (usize, Vec<EncryptionBatch>) {
 
     while raw_chunks.peek().is_some() {
         let _ = batches.push(EncryptionBatch {
-            data_size: bytes.len(),
             raw_chunks: raw_chunks.by_ref().take(chunks_per_batch).collect(),
         });
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,8 +28,8 @@ pub enum Error {
     Decryption(#[source] BlockModeError),
     #[error(display = "A generic I/O error")]
     Io(#[source] IoError),
-    #[error(display = "StorageError({:?})", _0)]
-    Storage(String),
+    #[error(display = "Too few bytes were decrypted ({}), expected {}", _0, _1)]
+    TooFewBytesDecrypted(usize, usize),
     #[error(display = "Generic error({})", _0)]
     Generic(String),
     #[error(display = "Serialisation error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,8 +176,16 @@ pub fn decrypt_range(
         .sorted_by_key(|c| c.index)
         .cloned() // should not be needed, something is wrong here, the docs for sorted_by_key says it will return owned items...!
         .collect_vec();
-    decrypt::decrypt(src_hashes, encrypted_chunks)
-        .map(|b| b.slice(relative_pos..(relative_pos + len)))
+    let bytes = decrypt::decrypt(src_hashes, encrypted_chunks)?;
+    if relative_pos + len > bytes.len() {
+        Err(Error::Generic(format!(
+            "Too few bytes were decrypted: {} (expected {})",
+            bytes.len(),
+            relative_pos + len
+        )))
+    } else {
+        Ok(bytes.slice(relative_pos..(relative_pos + len)))
+    }
 }
 
 /// Helper function to XOR a data with a pad (pad will be rotated to fill the length)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,11 +178,7 @@ pub fn decrypt_range(
         .collect_vec();
     let bytes = decrypt::decrypt(src_hashes, encrypted_chunks)?;
     if relative_pos + len > bytes.len() {
-        Err(Error::Generic(format!(
-            "Too few bytes were decrypted: {} (expected {})",
-            bytes.len(),
-            relative_pos + len
-        )))
+        Err(Error::TooFewBytesDecrypted(bytes.len(), relative_pos + len))
     } else {
         Ok(bytes.slice(relative_pos..(relative_pos + len)))
     }


### PR DESCRIPTION
- Check the `relative_pos + len` against the bytes before calling slice,
 as to avoid a panic from the fn if we did not have enough bytes.