### PR TITLE
chore: bump xor_name from 3.1.0 to 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rayon = "1.5.1"
 err-derive = "~0.3.1"
 num_cpus = "1.13.0"
 itertools = "~0.10.0"
-xor_name = "3.1.0"
+xor_name = "4.0.0"
 
   [dependencies.brotli]
   version = "~3.3.0"


### PR DESCRIPTION
this just bumps the xor_name version.   no code changes necessary.

note: this is needed in order to bump safe_network xor_name dep.

all tests pass locally.