### PR TITLE
chore: bump xor_name from 3.1.0 to 4.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rayon = "1.5.1"
 err-derive = "~0.3.1"
 num_cpus = "1.13.0"
 itertools = "~0.10.0"
-xor_name = "3.1.0"
+xor_name = "4.0.1"
 
   [dependencies.brotli]
   version = "~3.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,10 @@ use itertools::Itertools;
 use std::ops::Range;
 use xor_name::XorName;
 
+// export these because they are used in our public API.
+pub use bytes;
+pub use xor_name;
+
 /// The minimum size (before compression) of data to be self-encrypted, defined as 3kB.
 pub const MIN_ENCRYPTABLE_BYTES: usize = 3 * MIN_CHUNK_SIZE;
 /// The maximum size (before compression) of an individual chunk of the file, defined as 1MB.


### PR DESCRIPTION
also re-exports crates used in public API.