### PR TITLE
Get chunk size fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,11 +579,7 @@ fn get_chunk_size(file_size: usize, chunk_index: usize) -> usize {
         return 0;
     }
     if file_size < 3 * MAX_CHUNK_SIZE {
-        if chunk_index < 2 {
-            return file_size / 3;
-        } else {
-            return file_size - (2 * (file_size / 3));
-        }
+        return file_size / 3;
     }
     let total_chunks = get_num_chunks(file_size);
     if chunk_index < total_chunks - 2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,6 @@ impl StreamSelfDecryptor {
     // If the file already exists, the content will be appended to the end of the file.
     fn append_to_file(&self, content: &Bytes) -> std::io::Result<()> {
         let mut file = OpenOptions::new()
-            .write(true)
             .append(true)
             .create(true)
             .open(&*self.file_path)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -195,7 +195,7 @@ fn seek_indices_on_small_size_file() -> Result<(), Error> {
     assert_eq!(2, info.index_range.end);
 
     // last byte of index 2
-    let info = seek_info(file_size, file_size-1, 1);
+    let info = seek_info(file_size, file_size - 1, 1);
 
     assert_eq!(341, info.relative_pos);
     assert_eq!(2, info.index_range.start);
@@ -209,7 +209,7 @@ fn seek_indices_on_small_size_file() -> Result<(), Error> {
     assert_eq!(0, info.index_range.end);
 
     // last byte of index 2 (as 2 remainders in last chunk)
-    let info = seek_info(file_size+1, file_size, 1);
+    let info = seek_info(file_size + 1, file_size, 1);
 
     assert_eq!(342, info.relative_pos);
     assert_eq!(2, info.index_range.start);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -137,6 +137,39 @@ fn seek_indices() -> Result<(), Error> {
 }
 
 #[test]
+fn seek_indices_on_medium_size_file() -> Result<(), Error> {
+    let file_size = 969_265;
+    let pos = 0;
+    let len = 131072;
+
+    let info = seek_info(file_size, pos, len);
+
+    assert_eq!(0, info.relative_pos);
+    assert_eq!(0, info.index_range.start);
+    assert_eq!(0, info.index_range.end);
+
+    let info = seek_info(file_size, 131072, len);
+
+    assert_eq!(131072, info.relative_pos);
+    assert_eq!(0, info.index_range.start);
+    assert_eq!(0, info.index_range.end);
+
+    let info = seek_info(file_size, 393216, len);
+
+    assert_eq!(70128, info.relative_pos);
+    assert_eq!(1, info.index_range.start);
+    assert_eq!(1, info.index_range.end);
+
+    let info = seek_info(file_size, 655360, len);
+
+    assert_eq!(9184, info.relative_pos);
+    assert_eq!(2, info.index_range.start);
+    assert_eq!(2, info.index_range.end);
+
+    Ok(())
+}
+
+#[test]
 fn seek_and_join() -> Result<(), Error> {
     for i in 1..15 {
         let file_size = i * MIN_ENCRYPTABLE_BYTES;


### PR DESCRIPTION
- Updated the logic for calculating the chunk size when the chunk index is > 1 and the file size is less than 3 * MAX_CHUNK_SIZE (1.5 MB currently).
- The prior logic was incorrectly rounding, causing the size to be out by a small margin. This caused seek_info to return an incorrect relative_pos.
- Tested with 1 KB, 8 KB, 256 KB, 123456 bytes, 512 KB and 2048 KB over sn_httpd and confirmed all payloads were correct with Wireshark.


Link to issue:
https://github.com/maidsafe/self_encryption/issues/381

Link to issue:
https://github.com/maidsafe/safe_network/issues/1621