### PR TITLE
chore(release): 0.31.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "self_encryption"
 readme = "README.md"
 repository = "https://github.com/maidsafe/self_encryption"
-version = "0.32.43"
+version = "0.31.0"
 
 [features]
 default = []


### PR DESCRIPTION
This crate has had its version number bumped but it wasn't published.

It's being reset here for a publish.