### PR TITLE
feat: pass JS types into arrow fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["nodejs"]
+
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Self encrypting files (convergent encryption plus obfuscation)"

--- a/nodejs/__test__/from.spec.mjs
+++ b/nodejs/__test__/from.spec.mjs
@@ -37,20 +37,19 @@ test('streamingDecryptFromStorage', async (t) => {
   const { dataMap, chunks } = encrypt(data)
   const infos = dataMap.infos()
 
-  const getChunkParallel = (hexStrXorNames, abc) => {
+  const getChunkParallel = (xorNames) => {
     let chunkData = []
-    for (const hexStrXorName of hexStrXorNames) {
-      const xorName = XorName.fromHex(hexStrXorName)
+    for (const xorName of xorNames) {
       let found = false
       for (const info of infos) {
-        if (Buffer.from(info.dstHash.asBytes()).equals(xorName.asBytes())) {
+        if (info.dstHash.toHex() === xorName.toHex()) {
           chunkData.push(chunks[info.index].content())
           found = true
           break
         }
       }
       if (!found) {
-        throw new Error(`No chunk found for XOR: ${xorNameHexStr}`)
+        throw new Error(`No chunk found for XOR: ${xorName.toHex()}`)
       }
     }
 

--- a/nodejs/__test__/from.spec.mjs
+++ b/nodejs/__test__/from.spec.mjs
@@ -13,11 +13,9 @@ test('decryptFromStorage', async (t) => {
   const { dataMap, chunks } = encrypt(data)
   const infos = dataMap.infos()
 
-  const getChunk = (xorNameHexStr) => {
-    const xorName = XorName.fromHex(xorNameHexStr)
-
+  const getChunk = (xorName) => {
     for (const info of infos) {
-      if (Buffer.from(info.dstHash.asBytes()).equals(xorName.asBytes())) {
+      if (info.dstHash.toHex() === xorName.toHex()) {
         return chunks[info.index].content()
       }
     }
@@ -74,8 +72,8 @@ test('streamingEncryptFromFile', async (t) => {
   })
 
   fileName6 = crypto.randomBytes(16).toString('hex')
-  decryptFromStorage(dataMap, fileName6, (xorNameHexStr) => {
-    return map.get(xorNameHexStr)
+  decryptFromStorage(dataMap, fileName6, (xorName) => {
+    return map.get(xorName.toHex())
   })
   const dataRead = await fs.readFile(fileName6)
 
@@ -91,8 +89,8 @@ test('encryptFromFile and decryptFromStorage', async (t) => {
   await fs.mkdir(dirName1)
   const { dataMap, chunkNames } = encryptFromFile(fileName3, dirName1)
 
-  const getChunk = (xorNameHexStr) => {
-    return fsBlocking.readFileSync(dirName1 + path.sep + xorNameHexStr)
+  const getChunk = (xorName) => {
+    return fsBlocking.readFileSync(dirName1 + path.sep + xorName.toHex())
   }
 
   fileName4 = crypto.randomBytes(16).toString('hex')

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -47,7 +47,7 @@ export declare function decryptFromStorage(dataMap: DataMap, outputFile: string,
  * This function retrieves the encrypted chunks in parallel using the provided `getChunkParallel` function,
  * decrypts them, and writes the decrypted data directly to the specified output file path.
  */
-export declare function streamingDecryptFromStorage(dataMap: DataMap, outputFile: string, getChunkParallel: (...args: any[]) => any): void
+export declare function streamingDecryptFromStorage(dataMap: DataMap, outputFile: string, getChunkParallel: (xorNames: XorName[]) => Uint8Array): void
 export declare function streamingEncryptFromFile(filePath: string, chunkStore: (xorName: XorName, bytes: Uint8Array) => undefined): DataMap
 /**
  * Encrypt a file and store its chunks.

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -17,6 +17,14 @@
  * * `Error` - If the content hash doesn't match or deserialization fails
  */
 export declare function verifyChunk(name: XorName, bytes: Uint8Array): EncryptedChunk
+/** The minimum size (before compression) of an individual chunk of a file, defined as 1B. */
+export const MIN_CHUNK_SIZE: bigint
+/** The maximum size (before compression) of an individual chunk of a file, defaulting as 1MiB. */
+export const MAX_CHUNK_SIZE: bigint
+/** Controls the compression-speed vs compression-density tradeoffs. The higher the quality, the slower the compression. Range is 0 to 11. */
+export const COMPRESSION_QUALITY: number
+/** The minimum size (before compression) of data to be self-encrypted, defined as 3B. */
+export const MIN_ENCRYPTABLE_BYTES: bigint
 /**
  * Encrypt raw data into chunks.
  *
@@ -40,6 +48,7 @@ export declare function decryptFromStorage(dataMap: DataMap, outputFile: string,
  * decrypts them, and writes the decrypted data directly to the specified output file path.
  */
 export declare function streamingDecryptFromStorage(dataMap: DataMap, outputFile: string, getChunkParallel: (...args: any[]) => any): void
+export declare function streamingEncryptFromFile(filePath: string, chunkStore: (xorName: XorName, bytes: Uint8Array) => undefined): DataMap
 /**
  * Encrypt a file and store its chunks.
  *
@@ -62,6 +71,7 @@ export declare class XorName {
   static fromContent(content: Uint8Array): XorName
   /** Get the underlying bytes of the XorName. */
   asBytes(): Uint8Array
+  toHex(): string
   static fromHex(hex: string): XorName
 }
 /**

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -40,7 +40,7 @@ export declare function decrypt(dataMap: DataMap, chunks: Array<EncryptedChunk>)
  * This function retrieves encrypted chunks using the provided callback,
  * decrypts them according to the DataMap, and writes the result to a file.
  */
-export declare function decryptFromStorage(dataMap: DataMap, outputFile: string, getChunk: (...args: any[]) => any): void
+export declare function decryptFromStorage(dataMap: DataMap, outputFile: string, getChunk: (xorName: XorName) => Uint8Array): void
 /**
  * Decrypts data from storage in a streaming fashion using parallel chunk retrieval.
  *

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -310,9 +310,13 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { verifyChunk, XorName, ChunkInfo, DataMap, EncryptedChunk, encrypt, decrypt, decryptFromStorage, streamingDecryptFromStorage, encryptFromFile, EncryptFromFileResult, EncryptResult } = nativeBinding
+const { verifyChunk, MIN_CHUNK_SIZE, MAX_CHUNK_SIZE, COMPRESSION_QUALITY, MIN_ENCRYPTABLE_BYTES, XorName, ChunkInfo, DataMap, EncryptedChunk, encrypt, decrypt, decryptFromStorage, streamingDecryptFromStorage, streamingEncryptFromFile, encryptFromFile, EncryptFromFileResult, EncryptResult } = nativeBinding
 
 module.exports.verifyChunk = verifyChunk
+module.exports.MIN_CHUNK_SIZE = MIN_CHUNK_SIZE
+module.exports.MAX_CHUNK_SIZE = MAX_CHUNK_SIZE
+module.exports.COMPRESSION_QUALITY = COMPRESSION_QUALITY
+module.exports.MIN_ENCRYPTABLE_BYTES = MIN_ENCRYPTABLE_BYTES
 module.exports.XorName = XorName
 module.exports.ChunkInfo = ChunkInfo
 module.exports.DataMap = DataMap
@@ -321,6 +325,7 @@ module.exports.encrypt = encrypt
 module.exports.decrypt = decrypt
 module.exports.decryptFromStorage = decryptFromStorage
 module.exports.streamingDecryptFromStorage = streamingDecryptFromStorage
+module.exports.streamingEncryptFromFile = streamingEncryptFromFile
 module.exports.encryptFromFile = encryptFromFile
 module.exports.EncryptFromFileResult = EncryptFromFileResult
 module.exports.EncryptResult = EncryptResult

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -94,6 +94,11 @@ impl XorName {
     }
 
     #[napi]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0.0)
+    }
+
+    #[napi]
     pub fn from_hex(hex: String) -> Result<Self> {
         let mut bytes = [0u8; XOR_NAME_LEN];
         hex::decode_to_slice(hex, &mut bytes)


### PR DESCRIPTION
With a small workaround, we can pass JS `XorName`s to callbacks (arrow functions). Also adding TypeScript type hints to the callbacks to make it clear what the arrow fns expect.

- **feat: add XorName::to_hex for Node.js**
- **chore: nodejs workspace member**
- **feat: impl streaming encrypt for Node.js**
- **refactor: pass XorName as native Node.js type**
- **refactor: more native arguments in Node.js**
