### PR TITLE
feat(data_map): add backward compatibility for serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ features = ["rt"]
 criterion = "0.5.1"
 docopt = "~0.9.0"
 clap = { version = "4.4", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies.tokio]
 version = "1.34.0"

--- a/src/data_map.rs
+++ b/src/data_map.rs
@@ -6,21 +6,62 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Formatter, Write};
+use serde::{
+    de::{self, MapAccess, SeqAccess, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::fmt::{self, Debug, Formatter, Write};
 use xor_name::XorName;
 
 /// Holds the information that is required to recover the content of the encrypted file.
 /// This is held as a vector of `ChunkInfo`, i.e. a list of the file's chunk hashes.
 /// Only files larger than 3072 bytes (3 * MIN_CHUNK_SIZE) can be self-encrypted.
 /// Smaller files will have to be batched together.
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct DataMap {
     /// List of chunk hashes
     pub chunk_identifiers: Vec<ChunkInfo>,
     /// Child value, None means root data map and any other valuesignifies how
     /// many levels of data map we have shrunk
     pub child: Option<usize>,
+}
+
+impl DataMap {
+    /// Serialize DataMap to bytes using bincode
+    pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::Error> {
+        bincode::serialize(self)
+    }
+
+    /// Deserialize DataMap from bytes, handling both old and new formats
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, bincode::Error> {
+        // First, try to deserialize as the new versioned format
+        #[derive(Deserialize)]
+        struct VersionedDataMap {
+            version: u8,
+            chunk_identifiers: Vec<ChunkInfo>,
+            child: Option<usize>,
+        }
+
+        // Check if it's the new format by trying to deserialize it
+        if let Ok(versioned) = bincode::deserialize::<VersionedDataMap>(bytes) {
+            if versioned.version == 1 {
+                return Ok(DataMap {
+                    chunk_identifiers: versioned.chunk_identifiers,
+                    child: versioned.child,
+                });
+            }
+        }
+
+        // If that failed, try the old format (just Vec<ChunkInfo>)
+        match bincode::deserialize::<Vec<ChunkInfo>>(bytes) {
+            Ok(chunks) => Ok(DataMap {
+                chunk_identifiers: chunks,
+                child: None,
+            }),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -75,6 +116,130 @@ impl DataMap {
     /// Returns true if this DataMap has a child value
     pub fn is_child(&self) -> bool {
         self.child.is_some()
+    }
+}
+
+impl Serialize for DataMap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            // For JSON and other human-readable formats, use struct format
+            let mut st = serializer.serialize_struct("DataMap", 2)?;
+            st.serialize_field("chunk_identifiers", &self.chunk_identifiers)?;
+            st.serialize_field("child", &self.child)?;
+            st.end()
+        } else {
+            // For binary formats, prepend a version byte
+            // Version 1: New format with chunk_identifiers and child fields
+            #[derive(Serialize)]
+            struct VersionedDataMap<'a> {
+                version: u8,
+                chunk_identifiers: &'a Vec<ChunkInfo>,
+                child: &'a Option<usize>,
+            }
+            
+            let versioned = VersionedDataMap {
+                version: 1u8,
+                chunk_identifiers: &self.chunk_identifiers,
+                child: &self.child,
+            };
+            
+            versioned.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DataMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // For formats that support deserialize_any (like JSON)
+        if deserializer.is_human_readable() {
+            struct DataMapVisitor;
+
+            impl<'de> Visitor<'de> for DataMapVisitor {
+                type Value = DataMap;
+
+                fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, "either a Vec<ChunkInfo> (v0) or a struct (v1)")
+                }
+
+                // --- v0: the whole thing was just a sequence --------------------
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let mut chunks = Vec::new();
+                    while let Some(item) = seq.next_element()? {
+                        chunks.push(item);
+                    }
+                    Ok(DataMap {
+                        chunk_identifiers: chunks,
+                        child: None, // legacy files/network messages
+                    })
+                }
+
+                // --- v1: proper struct -----------------------------------------
+                fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                where
+                    A: MapAccess<'de>,
+                {
+                    let mut chunks: Option<Vec<ChunkInfo>> = None;
+                    let mut child: Option<Option<usize>> = None;
+
+                    while let Some(key) = map.next_key::<&str>()? {
+                        match key {
+                            "chunk_identifiers" => chunks = Some(map.next_value()?),
+                            "child" => child = Some(map.next_value()?),
+                            _ => {
+                                let _: de::IgnoredAny = map.next_value()?;
+                            }
+                        }
+                    }
+
+                    let chunk_identifiers =
+                        chunks.ok_or_else(|| de::Error::missing_field("chunk_identifiers"))?;
+                    Ok(DataMap {
+                        chunk_identifiers,
+                        child: child.flatten(), // default to None if field absent
+                    })
+                }
+            }
+
+            deserializer.deserialize_any(DataMapVisitor)
+        } else {
+            // For binary formats, we need to handle both old and new formats
+            // Try to peek at the first byte to check for version
+            #[derive(Deserialize)]
+            struct VersionedDataMap {
+                version: u8,
+                chunk_identifiers: Vec<ChunkInfo>,
+                child: Option<usize>,
+            }
+
+            // Since we can't peek with serde, we try the versioned format first
+            // If it starts with a reasonable version number (1), it's the new format
+            match VersionedDataMap::deserialize(deserializer) {
+                Ok(versioned) if versioned.version == 1 => {
+                    Ok(DataMap {
+                        chunk_identifiers: versioned.chunk_identifiers,
+                        child: versioned.child,
+                    })
+                }
+                _ => {
+                    // If it failed or has wrong version, it might be the old format
+                    // For the old format, we need to re-read from the beginning
+                    // This is a limitation - we can't truly try both formats with serde
+                    // In practice, this means we need external knowledge of the format
+                    Err(de::Error::custom(
+                        "Cannot determine binary format version. Migration required."
+                    ))
+                }
+            }
+        }
     }
 }
 
@@ -149,5 +314,147 @@ impl Debug for ChunkInfo {
             debug_bytes(self.src_hash),
             self.src_size
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_chunk_info(index: usize) -> ChunkInfo {
+        ChunkInfo {
+            index,
+            dst_hash: XorName::from_content(&format!("dst_{}", index).as_bytes()),
+            src_hash: XorName::from_content(&format!("src_{}", index).as_bytes()),
+            src_size: 1024 * (index + 1),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_old_format_json() {
+        // Create JSON representing the old tuple struct format: just an array
+        let chunks = vec![
+            create_test_chunk_info(0),
+            create_test_chunk_info(1),
+            create_test_chunk_info(2),
+        ];
+        let old_format_json = serde_json::to_string(&chunks).unwrap();
+
+        // Deserialize as DataMap
+        let data_map: DataMap = serde_json::from_str(&old_format_json).unwrap();
+
+        // Verify the data was correctly deserialized
+        assert_eq!(data_map.chunk_identifiers.len(), 3);
+        assert_eq!(data_map.child, None); // Should default to None for old format
+        assert_eq!(data_map.chunk_identifiers[0].index, 0);
+        assert_eq!(data_map.chunk_identifiers[1].index, 1);
+        assert_eq!(data_map.chunk_identifiers[2].index, 2);
+    }
+
+    #[test]
+    fn test_deserialize_new_format_json() {
+        // Create a DataMap with the new format
+        let chunks = vec![create_test_chunk_info(0), create_test_chunk_info(1)];
+        let data_map = DataMap::with_child(chunks.clone(), 5);
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&data_map).unwrap();
+
+        // Verify the JSON contains the expected structure
+        assert!(json.contains("\"chunk_identifiers\""));
+        assert!(json.contains("\"child\":5"));
+
+        // Deserialize back
+        let deserialized: DataMap = serde_json::from_str(&json).unwrap();
+
+        // Verify
+        assert_eq!(deserialized.chunk_identifiers.len(), 2);
+        assert_eq!(deserialized.child, Some(5));
+        assert_eq!(deserialized.chunk_identifiers[0].index, 0);
+        assert_eq!(deserialized.chunk_identifiers[1].index, 1);
+    }
+
+    #[test]
+    fn test_new_format_without_child_json() {
+        // Create a DataMap without child
+        let chunks = vec![create_test_chunk_info(0)];
+        let data_map = DataMap::new(chunks.clone());
+
+        // Serialize and deserialize
+        let json = serde_json::to_string(&data_map).unwrap();
+        let deserialized: DataMap = serde_json::from_str(&json).unwrap();
+
+        // Verify
+        assert_eq!(deserialized.chunk_identifiers.len(), 1);
+        assert_eq!(deserialized.child, None);
+    }
+
+    #[test]
+    fn test_bincode_new_format() {
+        // Create and serialize with new format
+        let chunks = vec![create_test_chunk_info(0)];
+        let data_map = DataMap::with_child(chunks, 3);
+
+        let bytes = data_map.to_bytes().unwrap();
+        let deserialized = DataMap::from_bytes(&bytes).unwrap();
+
+        assert_eq!(deserialized.chunk_identifiers.len(), 1);
+        assert_eq!(deserialized.child, Some(3));
+    }
+
+    #[test]
+    fn test_bincode_old_format_compatibility() {
+        // Test that we can deserialize the old format (just Vec<ChunkInfo>)
+        let chunks = vec![create_test_chunk_info(0), create_test_chunk_info(1)];
+
+        // Simulate old format by encoding just the Vec
+        let old_format_bytes = bincode::serialize(&chunks).unwrap();
+
+        // Should successfully deserialize using from_bytes
+        let data_map = DataMap::from_bytes(&old_format_bytes).unwrap();
+
+        // Verify
+        assert_eq!(data_map.chunk_identifiers.len(), 2);
+        assert_eq!(data_map.child, None); // Old format has no child
+        assert_eq!(data_map.chunk_identifiers[0].index, 0);
+        assert_eq!(data_map.chunk_identifiers[1].index, 1);
+    }
+
+    #[test]
+    fn test_bincode_version_byte() {
+        // Verify that new format includes version byte
+        let chunks = vec![create_test_chunk_info(0)];
+        let data_map = DataMap::new(chunks);
+
+        let bytes = data_map.to_bytes().unwrap();
+        
+        // First byte should be the version (1)
+        assert!(bytes.len() > 0);
+        assert_eq!(bytes[0], 1u8);
+    }
+
+    #[test]
+    fn test_preserve_chunk_order() {
+        // Ensure that chunk ordering is preserved through serialization
+        let chunks = vec![
+            create_test_chunk_info(2),
+            create_test_chunk_info(0),
+            create_test_chunk_info(1),
+        ];
+
+        // DataMap::new should sort them
+        let data_map = DataMap::new(chunks);
+        assert_eq!(data_map.chunk_identifiers[0].index, 0);
+        assert_eq!(data_map.chunk_identifiers[1].index, 1);
+        assert_eq!(data_map.chunk_identifiers[2].index, 2);
+
+        // Serialize and deserialize
+        let json = serde_json::to_string(&data_map).unwrap();
+        let deserialized: DataMap = serde_json::from_str(&json).unwrap();
+
+        // Order should be preserved
+        assert_eq!(deserialized.chunk_identifiers[0].index, 0);
+        assert_eq!(deserialized.chunk_identifiers[1].index, 1);
+        assert_eq!(deserialized.chunk_identifiers[2].index, 2);
     }
 }


### PR DESCRIPTION
Add support for deserializing old DataMap format (tuple struct) while maintaining the new struct format. This ensures compatibility with existing serialized data in the network.

- Add custom Serialize/Deserialize implementations
- Support both old array format and new struct format for JSON
- Add version byte (1) to binary format for future compatibility
- Add to_bytes/from_bytes helpers for bincode with fallback
- Add comprehensive tests for backward compatibility

BREAKING CHANGE: Binary format now includes version byte. Old binary data can still be read via from_bytes() method.

🤖 Generated with [Claude Code](https://claude.ai/code)