### PR TITLE
chore: tweaks for the release

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,11 @@
+[workspace]
+changelog_update = false
+semver_check = false
+
+[[package]]
+name = "self_encryption"
+git_tag_name = "v{{ version }}"
+
+[[package]]
+name = "self-encryption-nodejs"
+release = false


### PR DESCRIPTION
Configure `release-plz` with the following:

* Do not update any changelog since we will do this either by human input or from Claude.
* Disable Semantic Versioning checks because we will be bumping using `cargo release`.
* Disable the internal `nodejs` crate from being processed for publish, tag, or release.
* Tag the `self_encryption` crate just using the version rather than the crate name. This is necessary because technically this repository is a workspace and so `release-plz` will automatically tag as `self_encryption-v<version>`, but since we only have one crate we are interested in releasing, we can just use the version number for the tag.