### PR TITLE
chore: release 0.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## [0.34.1] - 2025-09-09
+
+### Fixed
+- random streaming decryption handling different MAX_CHUNK_SIZE scheme.
+
 ## [0.34.0] - 2025-09-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0"
 name = "self_encryption"
 readme = "README.md"
 repository = "https://github.com/maidsafe/self_encryption"
-version = "0.34.0"
+version = "0.34.1"
 
 [features]
 default = []

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"
-self_encryption = { version = "0.34.0", path = ".." }
+self_encryption = { version = "0.34.1", path = ".." }
 
 [build-dependencies]
 napi-build = "2.0.1"


### PR DESCRIPTION
## [0.34.1] - 2025-09-09

### Fixed
- random streaming decryption handling different MAX_CHUNK_SIZE scheme.