### PR TITLE
chore(release): v0.34.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## [0.34.2] - 2025-10-08
+
+### Changed
+- Max chunk size is now set to 4MB by default. This is the default currently being used in
+  production and we are setting it here to avoid mistakes when building binaries that depend on self
+  encryption.
+
 ## [0.34.1] - 2025-09-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0"
 name = "self_encryption"
 readme = "README.md"
 repository = "https://github.com/maidsafe/self_encryption"
-version = "0.34.1"
+version = "0.34.2"
 
 [features]
 default = []

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"
-self_encryption = { version = "0.34.1", path = ".." }
+self_encryption = { version = "0.34.2", path = ".." }
 
 [build-dependencies]
 napi-build = "2.0.1"


### PR DESCRIPTION
Release for setting the max chunk size to 4MB.