### PR TITLE
feat: env var of STREAM_DECRYPT_BATCH_SIZE

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,18 +112,32 @@ pub use self::{
     error::{Error, Result},
     stream_decrypt::{streaming_decrypt, DecryptionStream},
     stream_encrypt::{stream_encrypt, ChunkStream, EncryptionStream},
-    stream_file::{streaming_decrypt_from_storage, streaming_encrypt_from_file, streaming_encrypt_datamaps_from_file},
+    stream_file::{
+        streaming_decrypt_from_storage, streaming_encrypt_datamaps_from_file,
+        streaming_encrypt_from_file,
+    },
 };
 use bytes::Bytes;
 use std::{
     fs::File,
     io::{Read, Write},
     path::Path,
+    sync::LazyLock,
 };
 
 // export these because they are used in our public API.
 pub use bytes;
 pub use xor_name;
+
+/// Batch size for streaming decrypt chunk fetching.
+///
+/// Can be overridden by the `STREAM_DECRYPT_BATCH_SIZE` environment variable.
+pub static STREAM_DECRYPT_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("STREAM_DECRYPT_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10)
+});
 
 /// The minimum size (before compression) of data to be self-encrypted, defined as 3B.
 pub const MIN_ENCRYPTABLE_BYTES: usize = 3 * MIN_CHUNK_SIZE;

--- a/src/stream_decrypt.rs
+++ b/src/stream_decrypt.rs
@@ -10,15 +10,11 @@
 
 use crate::{
     decrypt::decrypt_chunk, get_root_data_map_parallel, utils::extract_hashes, ChunkInfo, DataMap,
-    Result,
+    Result, STREAM_DECRYPT_BATCH_SIZE,
 };
 use bytes::Bytes;
 use std::ops::Range;
 use xor_name::XorName;
-
-/// Batch size for streaming decrypt chunk fetching
-/// With each batch, we fetch 10 chunks in parallel and decrypt them
-const STREAM_DECRYPT_BATCH_SIZE: usize = 10;
 
 /// Iterator that yields decrypted chunks as `Bytes` in streaming fashion.
 ///
@@ -75,7 +71,7 @@ where
         }
 
         let batch_end =
-            (self.current_batch_start + STREAM_DECRYPT_BATCH_SIZE).min(self.chunk_infos.len());
+            (self.current_batch_start + *STREAM_DECRYPT_BATCH_SIZE).min(self.chunk_infos.len());
         let batch_infos = &self.chunk_infos[self.current_batch_start..batch_end];
 
         // Extract chunk hashes for this batch

--- a/src/stream_file.rs
+++ b/src/stream_file.rs
@@ -11,7 +11,7 @@
 use crate::{
     decrypt_chunk, get_num_chunks, get_start_end_positions, shrink_data_map,
     utils::get_pad_key_and_iv, ChunkInfo, DataMap, EncryptedChunk, Error, Result, MAX_CHUNK_SIZE,
-    MIN_ENCRYPTABLE_BYTES,
+    MIN_ENCRYPTABLE_BYTES, STREAM_DECRYPT_BATCH_SIZE,
 };
 use bytes::Bytes;
 use std::{
@@ -267,12 +267,8 @@ where
     chunk_infos.sort_by_key(|info| info.index);
     let src_hashes = crate::extract_hashes(&root_map);
 
-    // Process chunks in batches to minimize memory usage
-    // Use a reasonable batch size - could be made configurable
-    const BATCH_SIZE: usize = 10;
-
-    for batch_start in (0..chunk_infos.len()).step_by(BATCH_SIZE) {
-        let batch_end = (batch_start + BATCH_SIZE).min(chunk_infos.len());
+    for batch_start in (0..chunk_infos.len()).step_by(*STREAM_DECRYPT_BATCH_SIZE) {
+        let batch_end = (batch_start + *STREAM_DECRYPT_BATCH_SIZE).min(chunk_infos.len());
         let batch_infos = &chunk_infos[batch_start..batch_end];
 
         // Extract chunk hashes for this batch


### PR DESCRIPTION
make decryption batch size a configurable env var STREAM_DECRYPT_BATCH_SIZE, which defaults to 10 as current.
It's also public exposed for callers to use.