### PR TITLE
feat: add per-stream decrypt batch sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## [0.36.0] - 2026-05-13
+
+### Added
+- Added `streaming_decrypt_with_batch_size` and `DecryptionStream::new_with_batch_size` for
+  per-stream tuning of decrypt chunk fetch batches.
+- Added `DEFAULT_STREAM_DECRYPT_BATCH_SIZE` and `stream_decrypt_batch_size` to expose the default
+  stream decrypt batch size.
+
+### Changed
+- `streaming_decrypt` continues to use `STREAM_DECRYPT_BATCH_SIZE`, but invalid values and `0` now
+  fall back to the default batch size.
+
 ## [0.35.0] - 2026-03-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0"
 name = "self_encryption"
 readme = "README.md"
 repository = "https://github.com/maidsafe/self_encryption"
-version = "0.35.0"
+version = "0.36.0"
 
 [features]
 default = []

--- a/nodejs/Cargo.toml
+++ b/nodejs/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"
-self_encryption = { version = "0.35.0", path = ".." }
+self_encryption = { version = "0.36.0", path = ".." }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/src/data_map.rs
+++ b/src/data_map.rs
@@ -48,7 +48,7 @@ impl DataMap {
     /// The algorithm requires this to be a sorted list to allow get_pad_iv_key to obtain the
     /// correct pre-encryption hashes for decryption/encryption.
     pub fn new(mut keys: Vec<ChunkInfo>) -> Self {
-        keys.sort_by(|a, b| a.index.cmp(&b.index));
+        keys.sort_by_key(|a| a.index);
         Self {
             chunk_identifiers: keys,
             child: None,
@@ -57,7 +57,7 @@ impl DataMap {
 
     /// Creates a new DataMap with a specified child value
     pub fn with_child(mut keys: Vec<ChunkInfo>, child: usize) -> Self {
-        keys.sort_by(|a, b| a.index.cmp(&b.index));
+        keys.sort_by_key(|a| a.index);
         Self {
             chunk_identifiers: keys,
             child: Some(child),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,7 @@ mod tests {
     use crate::test_helpers::random_bytes;
     use std::{
         io::Write,
+        process::Command,
         sync::{Arc, Mutex},
     };
     use tempfile::NamedTempFile;
@@ -680,6 +681,72 @@ mod tests {
             });
         }
         DataMap::new(chunks)
+    }
+
+    fn assert_stream_decrypt_batch_size_from_env(
+        env_value: Option<&str>,
+        expected: usize,
+    ) -> Result<()> {
+        let mut child = Command::new(std::env::current_exe()?);
+        let _ = child
+            .arg("--ignored")
+            .arg("--exact")
+            .arg("tests::stream_decrypt_batch_size_env_child")
+            .arg("--nocapture")
+            .env(
+                "SELF_ENCRYPTION_STREAM_DECRYPT_BATCH_SIZE_EXPECTED",
+                expected.to_string(),
+            );
+
+        if let Some(value) = env_value {
+            let _ = child.env("STREAM_DECRYPT_BATCH_SIZE", value);
+        } else {
+            let _ = child.env_remove("STREAM_DECRYPT_BATCH_SIZE");
+        }
+
+        let output = child.output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "child env test failed\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+        assert!(
+            stdout.contains("stream_decrypt_batch_size_env_child observed"),
+            "child env test did not run\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_stream_decrypt_batch_size_env_fallbacks() -> Result<()> {
+        assert_stream_decrypt_batch_size_from_env(None, DEFAULT_STREAM_DECRYPT_BATCH_SIZE)?;
+        assert_stream_decrypt_batch_size_from_env(
+            Some("not-a-number"),
+            DEFAULT_STREAM_DECRYPT_BATCH_SIZE,
+        )?;
+        assert_stream_decrypt_batch_size_from_env(Some("0"), DEFAULT_STREAM_DECRYPT_BATCH_SIZE)?;
+        assert_stream_decrypt_batch_size_from_env(Some("64"), 64)?;
+        Ok(())
+    }
+
+    #[test]
+    #[ignore]
+    fn stream_decrypt_batch_size_env_child() -> Result<()> {
+        let expected = match std::env::var("SELF_ENCRYPTION_STREAM_DECRYPT_BATCH_SIZE_EXPECTED") {
+            Ok(expected) => expected.parse::<usize>()?,
+            Err(_) => return Ok(()),
+        };
+
+        let observed = stream_decrypt_batch_size();
+        println!("stream_decrypt_batch_size_env_child observed {observed}");
+        assert_eq!(observed, expected);
+        Ok(())
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use xor_name::XorName;
 pub use self::{
     data_map::{ChunkInfo, DataMap},
     error::{Error, Result},
-    stream_decrypt::{streaming_decrypt, DecryptionStream},
+    stream_decrypt::{streaming_decrypt, streaming_decrypt_with_batch_size, DecryptionStream},
     stream_encrypt::{stream_encrypt, ChunkStream, EncryptionStream},
 };
 use bytes::Bytes;
@@ -124,12 +124,27 @@ pub use xor_name;
 /// Batch size for streaming decrypt chunk fetching.
 ///
 /// Can be overridden by the `STREAM_DECRYPT_BATCH_SIZE` environment variable.
+/// Invalid values and `0` fall back to [`DEFAULT_STREAM_DECRYPT_BATCH_SIZE`].
 pub static STREAM_DECRYPT_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("STREAM_DECRYPT_BATCH_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(10)
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_STREAM_DECRYPT_BATCH_SIZE)
 });
+
+/// Default batch size for streaming decrypt chunk fetching.
+pub const DEFAULT_STREAM_DECRYPT_BATCH_SIZE: usize = 10;
+
+/// Read the current streaming decrypt batch size.
+///
+/// This reads the legacy `STREAM_DECRYPT_BATCH_SIZE` environment variable on
+/// first use, falling back to [`DEFAULT_STREAM_DECRYPT_BATCH_SIZE`]. New code
+/// that needs explicit per-stream tuning should use
+/// [`streaming_decrypt_with_batch_size`].
+pub fn stream_decrypt_batch_size() -> usize {
+    *STREAM_DECRYPT_BATCH_SIZE
+}
 
 /// The minimum size (before compression) of data to be self-encrypted, defined as 3B.
 pub const MIN_ENCRYPTABLE_BYTES: usize = 3 * MIN_CHUNK_SIZE;
@@ -547,8 +562,7 @@ where
 
         if !missing_hashes.is_empty() {
             let new_chunks = get_chunk_parallel(&missing_hashes)?;
-            for ((_i, hash), (_j, chunk_data)) in missing_hashes.iter().zip(new_chunks.into_iter())
-            {
+            for ((_i, hash), (_j, chunk_data)) in missing_hashes.iter().zip(new_chunks) {
                 let _ = chunk_cache.insert(*hash, chunk_data);
             }
         }

--- a/src/stream_decrypt.rs
+++ b/src/stream_decrypt.rs
@@ -21,6 +21,9 @@ use xor_name::XorName;
 ///
 /// This provides memory-efficient decryption by processing chunks in batches
 /// and yielding them one at a time without buffering the entire file.
+/// The configured batch size caps the number of chunk hashes passed to each
+/// fetch callback invocation for both sequential iteration and random-access
+/// range reads.
 ///
 /// In addition to sequential streaming, this struct also supports random access
 /// to any byte range within the encrypted file using methods like `get_range()`,
@@ -51,6 +54,12 @@ where
     }
 
     /// Creates a new streaming decrypt iterator with an explicit batch size.
+    ///
+    /// The batch size limits how many chunks are fetched/decrypted per
+    /// callback invocation. This applies to sequential iterator consumption
+    /// and to random-access APIs such as [`Self::get_range`] and
+    /// [`Self::range`]. Range APIs still return the complete requested byte
+    /// range; large ranges may therefore perform multiple batched fetches.
     ///
     /// # Arguments
     ///
@@ -233,23 +242,22 @@ where
         // Sort by index to ensure correct order
         required_hashes.sort_by_key(|(index, _)| *index);
 
-        // Fetch the required chunks
-        let fetched_chunks = (self.get_chunk_parallel)(&required_hashes)?;
-
-        // Create a mapping for quick lookup
-        let chunk_map: HashMap<usize, Bytes> = fetched_chunks.into_iter().collect();
-
         // Decrypt the chunks in order and collect the bytes
         let mut all_bytes = Vec::new();
-        for chunk_index in start_chunk..=end_chunk {
-            if let Some(encrypted_content) = chunk_map.get(&chunk_index) {
-                let decrypted = decrypt_chunk(
-                    chunk_index,
-                    encrypted_content,
-                    &self.src_hashes,
-                    self.child_level,
-                )?;
-                all_bytes.extend_from_slice(&decrypted);
+        for batch_hashes in required_hashes.chunks(self.batch_size) {
+            let fetched_chunks = (self.get_chunk_parallel)(batch_hashes)?;
+            let chunk_map: HashMap<usize, Bytes> = fetched_chunks.into_iter().collect();
+
+            for (chunk_index, _) in batch_hashes {
+                if let Some(encrypted_content) = chunk_map.get(chunk_index) {
+                    let decrypted = decrypt_chunk(
+                        *chunk_index,
+                        encrypted_content,
+                        &self.src_hashes,
+                        self.child_level,
+                    )?;
+                    all_bytes.extend_from_slice(&decrypted);
+                }
             }
         }
 
@@ -533,7 +541,9 @@ where
 /// Creates a streaming decrypt iterator with an explicit batch size.
 ///
 /// This is the preferred API for callers that need to tune download
-/// throughput without relying on process-wide environment variables.
+/// throughput without relying on process-wide environment variables. The
+/// batch size caps the number of chunks requested from the fetch callback per
+/// invocation for both iterator reads and random-access range reads.
 pub fn streaming_decrypt_with_batch_size<F>(
     data_map: &DataMap,
     get_chunk_parallel: F,
@@ -683,6 +693,52 @@ mod tests {
         assert!(
             observed.iter().all(|size| *size <= 2),
             "all batches should respect explicit size, got {:?}",
+            observed
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_random_access_respects_explicit_batch_size() -> Result<()> {
+        let original_data = random_bytes(9_000_000);
+        let (data_map, encrypted_chunks) = encrypt(original_data.clone())?;
+
+        let mut storage = HashMap::new();
+        for chunk in encrypted_chunks {
+            let hash = crate::hash::content_hash(&chunk.content);
+            let _ = storage.insert(hash, chunk.content.to_vec());
+        }
+
+        let observed_batch_sizes = std::cell::RefCell::new(Vec::new());
+        let get_chunks = |hashes: &[(usize, XorName)]| -> Result<Vec<(usize, Bytes)>> {
+            observed_batch_sizes.borrow_mut().push(hashes.len());
+            let mut results = Vec::new();
+            for &(index, hash) in hashes {
+                if let Some(data) = storage.get(&hash) {
+                    results.push((index, Bytes::from(data.clone())));
+                } else {
+                    return Err(Error::Generic(format!(
+                        "Chunk not found: {}",
+                        hex::encode(hash)
+                    )));
+                }
+            }
+            Ok(results)
+        };
+
+        let stream = streaming_decrypt_with_batch_size(&data_map, get_chunks, 2)?;
+        let decrypted_data = stream.range_full()?;
+
+        assert_eq!(decrypted_data, original_data);
+        let observed = observed_batch_sizes.borrow();
+        assert!(
+            observed.len() >= 2,
+            "expected multiple range fetch batches, got {:?}",
+            observed
+        );
+        assert!(
+            observed.iter().all(|size| *size <= 2),
+            "range fetches should respect explicit size, got {:?}",
             observed
         );
         Ok(())

--- a/src/stream_decrypt.rs
+++ b/src/stream_decrypt.rs
@@ -9,8 +9,8 @@
 //! Streaming decryption functionality for memory-efficient processing of large encrypted files.
 
 use crate::{
-    decrypt::decrypt_chunk, get_root_data_map_parallel, utils::extract_hashes, ChunkInfo, DataMap,
-    Result, STREAM_DECRYPT_BATCH_SIZE,
+    decrypt::decrypt_chunk, get_root_data_map_parallel, stream_decrypt_batch_size,
+    utils::extract_hashes, ChunkInfo, DataMap, Result,
 };
 use bytes::Bytes;
 use std::collections::HashMap;
@@ -33,6 +33,7 @@ pub struct DecryptionStream<F> {
     current_batch_start: usize,
     current_batch_chunks: Vec<Bytes>,
     current_batch_index: usize,
+    batch_size: usize,
 }
 
 impl<F> DecryptionStream<F>
@@ -46,6 +47,27 @@ where
     /// * `data_map` - The data map containing chunk information
     /// * `get_chunk_parallel` - Function to retrieve chunks in parallel
     pub fn new(data_map: &DataMap, get_chunk_parallel: F) -> Result<Self> {
+        Self::new_with_batch_size(data_map, get_chunk_parallel, stream_decrypt_batch_size())
+    }
+
+    /// Creates a new streaming decrypt iterator with an explicit batch size.
+    ///
+    /// # Arguments
+    ///
+    /// * `data_map` - The data map containing chunk information
+    /// * `get_chunk_parallel` - Function to retrieve chunks in parallel
+    /// * `batch_size` - Number of chunks to fetch/decrypt per batch. Must be greater than 0.
+    pub fn new_with_batch_size(
+        data_map: &DataMap,
+        get_chunk_parallel: F,
+        batch_size: usize,
+    ) -> Result<Self> {
+        if batch_size == 0 {
+            return Err(crate::Error::Generic(
+                "stream decrypt batch size must be > 0".to_string(),
+            ));
+        }
+
         let root_map = if data_map.is_child() {
             get_root_data_map_parallel(data_map.clone(), &get_chunk_parallel)?
         } else {
@@ -65,6 +87,7 @@ where
             current_batch_start: 0,
             current_batch_chunks: Vec::new(),
             current_batch_index: 0,
+            batch_size,
         })
     }
 
@@ -74,8 +97,10 @@ where
             return Ok(false); // No more chunks
         }
 
-        let batch_end =
-            (self.current_batch_start + *STREAM_DECRYPT_BATCH_SIZE).min(self.chunk_infos.len());
+        let batch_end = self
+            .current_batch_start
+            .saturating_add(self.batch_size)
+            .min(self.chunk_infos.len());
         let batch_infos = self
             .chunk_infos
             .get(self.current_batch_start..batch_end)
@@ -100,9 +125,7 @@ where
 
         // Decrypt each chunk and store the results
         self.current_batch_chunks.clear();
-        for (info, (_index, encrypted_content)) in
-            batch_infos.iter().zip(fetched_chunks.into_iter())
-        {
+        for (info, (_index, encrypted_content)) in batch_infos.iter().zip(fetched_chunks) {
             let decrypted_chunk = decrypt_chunk(
                 info.index,
                 &encrypted_content,
@@ -507,6 +530,21 @@ where
     DecryptionStream::new(data_map, get_chunk_parallel)
 }
 
+/// Creates a streaming decrypt iterator with an explicit batch size.
+///
+/// This is the preferred API for callers that need to tune download
+/// throughput without relying on process-wide environment variables.
+pub fn streaming_decrypt_with_batch_size<F>(
+    data_map: &DataMap,
+    get_chunk_parallel: F,
+    batch_size: usize,
+) -> Result<DecryptionStream<F>>
+where
+    F: Fn(&[(usize, XorName)]) -> Result<Vec<(usize, Bytes)>>,
+{
+    DecryptionStream::new_with_batch_size(data_map, get_chunk_parallel, batch_size)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -597,6 +635,71 @@ mod tests {
 
         assert_eq!(decrypted_data, original_data.to_vec());
         assert!(chunk_count > 1, "Should have processed multiple chunks");
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_decrypt_explicit_batch_size() -> Result<()> {
+        let original_data = random_bytes(9_000_000);
+        let (data_map, encrypted_chunks) = encrypt(original_data.clone())?;
+
+        let mut storage = HashMap::new();
+        for chunk in encrypted_chunks {
+            let hash = crate::hash::content_hash(&chunk.content);
+            let _ = storage.insert(hash, chunk.content.to_vec());
+        }
+
+        let observed_batch_sizes = std::cell::RefCell::new(Vec::new());
+        let get_chunks = |hashes: &[(usize, XorName)]| -> Result<Vec<(usize, Bytes)>> {
+            observed_batch_sizes.borrow_mut().push(hashes.len());
+            let mut results = Vec::new();
+            for &(index, hash) in hashes {
+                if let Some(data) = storage.get(&hash) {
+                    results.push((index, Bytes::from(data.clone())));
+                } else {
+                    return Err(Error::Generic(format!(
+                        "Chunk not found: {}",
+                        hex::encode(hash)
+                    )));
+                }
+            }
+            Ok(results)
+        };
+
+        let stream = streaming_decrypt_with_batch_size(&data_map, get_chunks, 2)?;
+        let mut decrypted_data = Vec::new();
+        for chunk_result in stream {
+            let chunk = chunk_result?;
+            decrypted_data.extend_from_slice(&chunk);
+        }
+
+        assert_eq!(decrypted_data, original_data.to_vec());
+        let observed = observed_batch_sizes.borrow();
+        assert!(
+            observed.len() >= 2,
+            "expected multiple fetch batches, got {:?}",
+            observed
+        );
+        assert!(
+            observed.iter().all(|size| *size <= 2),
+            "all batches should respect explicit size, got {:?}",
+            observed
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_decrypt_explicit_batch_size_rejects_zero() -> Result<()> {
+        let original_data = random_bytes(50_000);
+        let (data_map, _encrypted_chunks) = encrypt(original_data)?;
+        let get_chunks =
+            |_hashes: &[(usize, XorName)]| -> Result<Vec<(usize, Bytes)>> { Ok(Vec::new()) };
+
+        let err = match streaming_decrypt_with_batch_size(&data_map, get_chunks, 0) {
+            Ok(_) => panic!("zero batch size should fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("> 0"), "got: {}", err);
         Ok(())
     }
 
@@ -979,6 +1082,7 @@ mod tests {
             current_batch_start: 0,
             current_batch_chunks: Vec::new(),
             current_batch_index: 0,
+            batch_size: stream_decrypt_batch_size(),
         };
 
         // Use the new get_chunk_index_from_infos method instead of the utility function


### PR DESCRIPTION
## Summary
- add explicit per-stream decrypt batch-size APIs alongside the existing env-var default
- keep the legacy streaming_decrypt wrapper behavior unchanged
- bump self_encryption to 0.36.0 for the public API addition

## Verification
- cargo test